### PR TITLE
[WIP] Initial attempt at supporting default unit settings

### DIFF
--- a/src/convert.py
+++ b/src/convert.py
@@ -97,7 +97,7 @@ def register_exchange_rates(exchange_rates):
         ureg.define(definition)
 
 
-def convert(query, decimal_places=2):
+def convert(query, decimal_places=2, auto_convert=None):
     """Parse query, calculate and return conversion result.
 
     Args:
@@ -129,9 +129,14 @@ def convert(query, decimal_places=2):
     atoms = tail.split()
     from_unit = to_unit = None
     # Try splitting tail at every space until we arrive at a pair
-    # of units that `pint` understands
+    # of units that `pint` understands. If we only have a single unit,
+    # then check to see if perhaps we have a default conversion set
     if len(atoms) == 1:
-        raise ValueError('No destination unit specified')
+        if atoms[0] not in auto_convert:
+            raise ValueError('No destination unit specified')
+        else:
+            atoms += auto_convert[atoms[0]]
+
     q1 = q2 = ''
     for i in range(len(atoms)):
         from_unit = to_unit = None  # reset so no old values spill over
@@ -216,9 +221,11 @@ def main(wf):
     conversion = None
 
     try:
-        conversion = convert(query,
-                             decimal_places=wf.settings.get('decimal_places',
-                                                            2))
+        conversion = convert(
+            query,
+            decimal_places=wf.settings.get('decimal_places', 2),
+            auto_convert=wf.settings.get('auto_convert', {})
+        )
     except UndefinedUnitError as err:
         log.critical('Unknown unit : %s', err.unit_names)
         error = 'Unknown unit : {0}'.format(err.unit_names)


### PR DESCRIPTION
This is a very, very rough draft of playing with the idea from #13 

This assumes a settings file like the following

```
{
  "auto_convert": {
    "degC": [
      "degF"
    ],
    "km": [
      "mi"
    ],
    "mi": [
      "km"
    ]
  }
}
```

I've kept the settings as a list for now, since that's what the original ticket talked about, but since this was just my first prototype, it only works with a single conversion. I would need to change additional logic to have something like km -> miles, meters (one unit showing the result for two different destinations)

I'm sure this pull request is nowhere near ready for anything, but I thought it would be good to put a bit of code out there to start the discussion. At a very minimum I would imagine that @deanishe will have a few preferences on naming conventions for variables and layout of the settings file :) 
