### PR TITLE
Improve handling of Currency update responses

### DIFF
--- a/src/currency.py
+++ b/src/currency.py
@@ -171,6 +171,14 @@ def load_active_currencies():
     return symbols
 
 
+def is_valid_currency(currency):
+    return isinstance(currency, basestring) and (currency in CURRENCIES or currency in CRYPTO_CURRENCIES)
+
+
+def is_valid_exchange_rate(rate):
+    return isinstance(rate, int) or isinstance(rate, float)
+
+
 def fetch_exchange_rates():
     """Retrieve all currency exchange rates.
 
@@ -205,7 +213,7 @@ def fetch_exchange_rates():
             continue
         if s in active:
             syms.append(s)
-    # syms = [s for s in CRYPTO_CURRENCIES.keys() if s in active]
+
     for symbols in grouper(SYMBOLS_PER_REQUEST, syms):
         jobs.append((load_cryptocurrency_rates, (symbols,)))
 
@@ -218,7 +226,12 @@ def fetch_exchange_rates():
     pool.join()
 
     for f in futures:
-        rates.update(f.get())
+        for currency, rate in f.get().iteritems():
+            if is_valid_currency(currency) and is_valid_exchange_rate(rate):
+                rates[currency] = rate
+                log.debug("Currency %s has new rate %s", currency, rate)
+            else:
+                log.warn("Got invalid rate update for currency '%s' to '%s'", currency, rate)
 
     return rates
 

--- a/src/currency.py
+++ b/src/currency.py
@@ -77,6 +77,10 @@ def load_cryptocurrency_rates(symbols):
     r.raise_for_status()
 
     data = r.json()
+    if data[u'Response'] == u'Error':
+        log.warn('Got error from crypto exchange: %s', data)
+        return {}
+
     for sym, rate in data.items():
         log.debug('[CryptoCompare.com] 1 %s = %s %s',
                   REFERENCE_CURRENCY, rate, sym)


### PR DESCRIPTION
There are two commits here:
1. Generically reject any currency updates unless both are true:
   1. the currency is in `CURRENCIES` or `CRYPTO_CURRENCIES`
   1. the rate is a number.
1. Explicitly handle throttling responses from Cryptocompare.com's API which unfortunately use a HTTP 200 instead of a 429 or similar.

This should help with #74 .