### PR TITLE
Use pyenv instead of system python to add macOS 12.3+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ All other code/media are released under the [MIT Licence][mit].
 [fontawesome]: http://fortawesome.github.io/Font-Awesome/
 [ghissues]: https://github.com/deanishe/alfred-convert/issues
 [ghpulls]: https://github.com/deanishe/alfred-convert/pulls
-[ghreleases]: https://github.com/deanishe/alfred-convert/releases
+[ghreleases]: https://github.com/willemml/alfred-convert/releases
 [mit]: http://opensource.org/licenses/MIT
 [pintdocs]: http://pint.readthedocs.org/en/latest/index.html
 [pinthowto]: http://pint.readthedocs.org/en/latest/defining.html

--- a/README.md
+++ b/README.md
@@ -14,18 +14,20 @@ You can also add your own custom units.
 
 <!-- MarkdownTOC autolink="true" bracket="round" depth="2" autoanchor="true" -->
 
-- [Downloading](#downloading)
-- [Usage](#usage)
-  - [Conversions](#conversions)
-  - [Configuration](#configuration)
-    - [Configuration sheet](#configuration-sheet)
-    - [Active currencies](#active-currencies)
-    - [Custom units](#custom-units)
-- [Supported units](#supported-units)
-  - [Supported currencies](#supported-currencies)
-  - [Adding custom units](#adding-custom-units)
-- [Releases](#releases)
-- [Thanks, copyright, licensing](#thanks-copyright-licensing)
+- [Alfred-Convert](#alfred-convert)
+  - [Downloading](#downloading)
+  - [macOS 12.3 and later](#macos-123-and-later)
+  - [Usage](#usage)
+    - [Conversions](#conversions)
+    - [Configuration](#configuration)
+      - [Configuration sheet](#configuration-sheet)
+      - [Active currencies](#active-currencies)
+      - [Custom units](#custom-units)
+  - [Supported units](#supported-units)
+    - [Supported currencies](#supported-currencies)
+    - [Adding custom units](#adding-custom-units)
+  - [Releases](#releases)
+  - [Thanks, copyright, licensing](#thanks-copyright-licensing)
 
 <!-- /MarkdownTOC -->
 
@@ -38,6 +40,31 @@ Download from [GitHub releases][ghreleases].
 
 **Note**: Version 3.7 and above only supports Alfred 4+. If you're still using Alfred 3, please download [v3.6.2][v3.6.2].
 
+<a name="newmacos"></a>
+macOS 12.3 and later
+-----------
+
+As of macOS 12.3 Python 2.7 is no longer incleded in macOS by default so you will need to install it.
+In this fork I have added **pyenv** as a requirement. 
+
+Install it using [Homebrew](https://brew.sh/):
+```zsh
+brew install pyenv
+```
+
+Add it to your ZSH profile (or go to the [pyenv installation guide](https://github.com/pyenv/pyenv#basic-github-checkout) for more options):
+```zsh
+echo 'eval "$(pyenv init --path)"' >> ~/.zprofile
+
+echo 'eval "$(pyenv init -)"' >> ~/.zshrc
+```
+
+Then install Python 2.7 using pyenv:
+```zsh
+pyenv install pypy2.7-7.3.6
+```
+
+Once you have pyenv installed make sure to edit the `PYTHONEXECUTABLE` variable in `workflow/workflow.py` (should be on line 57) replacing `YOURUSERNAME` with the your username (this should be the same as the name of your home folder, otherwise get this by running `whoami` in Terminal). You can find the `workflow` folder containing `workflow.py` by right clicking on the workflow in the workflow tab of Alfred and then clicking "Open in Finder".
 
 <a name="usage"></a>
 Usage

--- a/src/convert.py
+++ b/src/convert.py
@@ -18,6 +18,7 @@ import sys
 from pint import UnitRegistry, UndefinedUnitError, DimensionalityError
 
 from workflow import Workflow3, ICON_WARNING, ICON_INFO
+from workflow.workflow import PYTHONEXECUTABLE
 from workflow.background import run_in_background, is_running
 from workflow.update import Version
 from config import (
@@ -667,7 +668,7 @@ def main(wf):
 
     if not wf.cached_data_fresh(CURRENCY_CACHE_NAME, CURRENCY_CACHE_AGE):
         # Update currency rates
-        cmd = ['/usr/bin/python', wf.workflowfile('currency.py')]
+        cmd = [PYTHONEXECUTABLE, wf.workflowfile('currency.py')]
         run_in_background('update', cmd)
         wf.rerun = 0.5
 

--- a/src/info.plist
+++ b/src/info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>bundleid</key>
 	<string>net.deanishe.alfred-convert</string>
+	<key>category</key>
+	<string>Tools</string>
 	<key>connections</key>
 	<dict>
 		<key>1E12C11D-30DB-44A8-AD75-F5BE7F2DA451</key>
@@ -174,6 +176,8 @@
 				<false/>
 				<key>clipboardtext</key>
 				<string>{query}</string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
 				<key>transient</key>
 				<false/>
 			</dict>
@@ -235,7 +239,13 @@
 echo "http_proxy=$http_proxy"&gt;&amp;2
 echo "https_proxy=$https_proxy"&gt;&amp;2
 
-/usr/bin/python convert.py "$1"</string>
+PYENV_ORIG_VALUE=$(/opt/homebrew/bin/pyenv global)
+
+/opt/homebrew/bin/pyenv global pypy2.7-7.3.6
+
+/opt/homebrew/bin/pyenv exec python convert.py "$1"
+
+/opt/homebrew/bin/pyenv global $PYENV_ORIG_VALUE</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -245,7 +255,7 @@ echo "https_proxy=$https_proxy"&gt;&amp;2
 				<key>title</key>
 				<string>Convert a Quantity</string>
 				<key>type</key>
-				<integer>0</integer>
+				<integer>5</integer>
 				<key>withspace</key>
 				<true/>
 			</dict>
@@ -391,7 +401,13 @@ variables={allvars}</string>
 				<key>runningsubtext</key>
 				<string></string>
 				<key>script</key>
-				<string>/usr/bin/python info.py "$1"</string>
+				<string>PYENV_ORIG_VALUE=$(/opt/homebrew/bin/pyenv global)
+
+/opt/homebrew/bin/pyenv global pypy2.7-7.3.6
+
+/opt/homebrew/bin/pyenv exec python info.py "$1"
+
+/opt/homebrew/bin/pyenv global $PYENV_ORIG_VALUE</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>

--- a/src/info.plist
+++ b/src/info.plist
@@ -231,7 +231,7 @@
 				<key>queuedelaymode</key>
 				<integer>1</integer>
 				<key>queuemode</key>
-				<integer>1</integer>
+				<integer>2</integer>
 				<key>runningsubtext</key>
 				<string>Convertifying…</string>
 				<key>script</key>
@@ -239,13 +239,7 @@
 echo "http_proxy=$http_proxy"&gt;&amp;2
 echo "https_proxy=$https_proxy"&gt;&amp;2
 
-PYENV_ORIG_VALUE=$(/opt/homebrew/bin/pyenv global)
-
-/opt/homebrew/bin/pyenv global pypy2.7-7.3.6
-
-/opt/homebrew/bin/pyenv exec python convert.py "$1"
-
-/opt/homebrew/bin/pyenv global $PYENV_ORIG_VALUE</string>
+/Users/$(whoami)/.pyenv/versions/pypy2.7-7.3.6/bin/python convert.py "$1"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -255,7 +249,7 @@ PYENV_ORIG_VALUE=$(/opt/homebrew/bin/pyenv global)
 				<key>title</key>
 				<string>Convert a Quantity</string>
 				<key>type</key>
-				<integer>5</integer>
+				<integer>0</integer>
 				<key>withspace</key>
 				<true/>
 			</dict>
@@ -401,13 +395,7 @@ variables={allvars}</string>
 				<key>runningsubtext</key>
 				<string></string>
 				<key>script</key>
-				<string>PYENV_ORIG_VALUE=$(/opt/homebrew/bin/pyenv global)
-
-/opt/homebrew/bin/pyenv global pypy2.7-7.3.6
-
-/opt/homebrew/bin/pyenv exec python info.py "$1"
-
-/opt/homebrew/bin/pyenv global $PYENV_ORIG_VALUE</string>
+				<string>/Users/$(whoami)/.pyenv/versions/pypy2.7-7.3.6/bin/python info.py "$1"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -660,7 +648,7 @@ UPDATE_INTERVAL is the number of minutes between exchange rate updates.</string>
 		<key>CURRENCY_DECIMAL_PLACES</key>
 		<string>2</string>
 		<key>DECIMAL_PLACES</key>
-		<string>2</string>
+		<string>4</string>
 		<key>DECIMAL_SEPARATOR</key>
 		<string>.</string>
 		<key>DYNAMIC_DECIMALS</key>
@@ -675,7 +663,7 @@ UPDATE_INTERVAL is the number of minutes between exchange rate updates.</string>
 		<string>APP_KEY</string>
 	</array>
 	<key>version</key>
-	<string>3.7.1</string>
+	<string>3.7.3</string>
 	<key>webaddress</key>
 	<string></string>
 </dict>

--- a/src/workflow/background.py
+++ b/src/workflow/background.py
@@ -26,6 +26,7 @@ import subprocess
 import pickle
 
 from workflow import Workflow
+from workflow import PYTHONEXECUTABLE
 
 __all__ = ['is_running', 'run_in_background']
 
@@ -230,7 +231,7 @@ def run_in_background(name, args, **kwargs):
         _log().debug('[%s] command cached: %s', name, argcache)
 
     # Call this script
-    cmd = ['/usr/bin/python', __file__, name]
+    cmd = [PYTHONEXECUTABLE, __file__, name]
     _log().debug('[%s] passing job to background runner: %r', name, cmd)
     retcode = subprocess.call(cmd)
 

--- a/src/workflow/workflow.py
+++ b/src/workflow/workflow.py
@@ -54,8 +54,8 @@ from util import (
 ####################################################################
 # Python executable path
 ####################################################################
-PYTHONEXECUTABLE = "/Users/YOURUSERNAME/.pyenv/versions/pypy2.7-7.3.6/bin/python"
-
+HOMEPATH = os.getenv('HOME')
+PYTHONEXECUTABLE = HOMEPATH + '/.pyenv/versions/pypy2.7-7.3.6/bin/python'
 
 
 #: Sentinel for properties that haven't been set yet (that might
@@ -2342,7 +2342,6 @@ class Workflow(object):
                 cmd.append('--prereleases')
 
             self.logger.info('checking for update ...')
-
             run_in_background('__workflow_update_check', cmd)
 
         else:

--- a/src/workflow/workflow.py
+++ b/src/workflow/workflow.py
@@ -51,6 +51,13 @@ from util import (
     uninterruptible,
 )
 
+####################################################################
+# Python executable path
+####################################################################
+PYTHONEXECUTABLE = "/Users/YOURUSERNAME/.pyenv/versions/pypy2.7-7.3.6/bin/python"
+
+
+
 #: Sentinel for properties that haven't been set yet (that might
 #: correctly have the value ``None``)
 UNSET = object()
@@ -402,7 +409,6 @@ DUMB_PUNCTUATION = {
     '–': '-',
     '—': '-'
 }
-
 
 ####################################################################
 # Used by `Workflow.filter`
@@ -2330,7 +2336,7 @@ class Workflow(object):
             update_script = os.path.join(os.path.dirname(__file__),
                                          b'update.py')
 
-            cmd = ['/usr/bin/python', update_script, 'check', repo, version]
+            cmd = [PYTHONEXECUTABLE, update_script, 'check', repo, version]
 
             if self.prereleases:
                 cmd.append('--prereleases')
@@ -2369,7 +2375,7 @@ class Workflow(object):
         update_script = os.path.join(os.path.dirname(__file__),
                                      b'update.py')
 
-        cmd = ['/usr/bin/python', update_script, 'install', repo, version]
+        cmd = [PYTHONEXECUTABLE, update_script, 'install', repo, version]
 
         if self.prereleases:
             cmd.append('--prereleases')


### PR DESCRIPTION
Exactly as the title says, as of macOS 12.3 Python 2.7 is no longer supported so this is a workaround until this is re-written for Python 3 or someone makes an alternative. 

This is by no means an ideal fix, as it hugely complicates the installation process, but it is a fix. Another problem with this is that it unnecessarily inconveniences people who have not or cannot upgrade to macOS 12.3. 

Temporary solution to #91.